### PR TITLE
Fix image size bugs (partly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Opencv does not implement the gpu version of the sgbm algorithm, this project is
 
 After other people’s tests, the input image size is recommended to be 640*480. I don't limit the size of the image in the program, but I don't know why other sizes can't work.
 
+> NOTE: This bug was fixed partly in commit `df82a9f2c4c2369bd6b327def4da6ad928375c3e`, max image size = [2048, 1024]
+
 
 **How to compile and use**  
 mkdir build  

--- a/aggregation.h
+++ b/aggregation.h
@@ -9,6 +9,7 @@ __global__ void cost_aggregation_rl_ud(const CostType *d_cost, CostType *d_sp, i
 __global__ void cost_aggregation_rl(const CostType *d_cost, CostType *d_sp, int p1, int p2, int cols, int rows);
 
 __global__ void get_disparity(const CostType *d_sp, DispType *d_disp, CostType *d_mins, int uniquenessRatio, DispType * d_raw_disp, CostType *disp2cost, DispType *disp2, int cols, int rows);
+__global__ void get_disparity_ex(const CostType *d_sp, DispType *d_disp, CostType *d_mins, int uniquenessRatio, DispType * d_raw_disp, CostType *disp2cost, DispType *disp2, int cols, int rows);
 __global__ void lrcheck(DispType * d_disp, const CostType * d_mins, DispType *disp2, CostType *disp2cost, CostType *d_raw_disp, int disp12MaxDiff, int cols, int rows);
 
 __global__ void MedianFilter(const DispType *d_input, DispType *d_out, int rows, int cols);


### PR DESCRIPTION
Fix #4 . Now allowed max image size is [2048, 1024] and it is easy to change codes for larger images. I have tested on Ubuntu 20.04 with GCC /G++7.5, CUDA 10.0, OpenCV 3.2.10 and got expected results. 

Thansk for you jobs! 👍